### PR TITLE
A small tweak in the build-mfem action

### DIFF
--- a/build-mfem/action.yml
+++ b/build-mfem/action.yml
@@ -86,7 +86,7 @@ runs:
           DEBUG="YES";
           BUILD_TYPE="Debug";
         fi
-        if [[ ${{ inputs.os }} != 'ubuntu-18.04' || \
+        if [[ ${{ runner.os }} != 'Linux' || \
               ${{ inputs.target }} == 'dbg' ]]; then
           CPPFLAGS+=" -pedantic -Wall -Werror";
         fi


### PR DESCRIPTION
Use `runner.os` (possible values `Linux`, `Windows`, or `macOS`) instead of `inputs.os` which is passed by the user of this action and may be incorrect.