### PR TITLE
Fix lcov CI failures

### DIFF
--- a/upload-coverage/action.yml
+++ b/upload-coverage/action.yml
@@ -36,7 +36,7 @@ runs:
           for dir in ${directory_list}; do dirs_opts+=" --directory=${dir}"; done
         fi
         # Generate the coverage report.
-        lcov --no-external --gcov-tool gcov ${dirs_opts} --capture --output-file lcov.info;
+        lcov --ignore-errors inconsistent --no-external --gcov-tool gcov ${dirs_opts} --capture --output-file lcov.info;
         # The variable $RUNNER_OS should be either "Linux" or "macOS"
         os_lowercase=$(echo $RUNNER_OS | awk '{print tolower($0)}')
         # The prefix will end with "linux" or "macos" depending on the runner OS

--- a/upload-coverage/action.yml
+++ b/upload-coverage/action.yml
@@ -36,7 +36,7 @@ runs:
           for dir in ${directory_list}; do dirs_opts+=" --directory=${dir}"; done
         fi
         # Generate the coverage report.
-        lcov --ignore-errors inconsistent --no-external --gcov-tool gcov ${dirs_opts} --capture --output-file lcov.info;
+        lcov --keep-going --no-external --gcov-tool gcov ${dirs_opts} --capture --output-file lcov.info;
         # The variable $RUNNER_OS should be either "Linux" or "macOS"
         os_lowercase=$(echo $RUNNER_OS | awk '{print tolower($0)}')
         # The prefix will end with "linux" or "macos" depending on the runner OS

--- a/upload-coverage/action.yml
+++ b/upload-coverage/action.yml
@@ -30,13 +30,17 @@ runs:
     - run: |
         cd ${{ inputs.project_dir }}
         # Restrict search to directories listed, if any.
-        directory_list="${{ inputs.directories }}";
-        dirs_opts="";
+        directory_list="${{ inputs.directories }}"
+        dirs_opts=""
         if [[ -n "${directory_list}" ]]; then
           for dir in ${directory_list}; do dirs_opts+=" --directory=${dir}"; done
         fi
+        keep_going_flag=""
+        if [[ "$(lcov --version)" =~ "lcov: LCOV version 2" ]]; then
+          keep_going_flag="--keep-going"
+        fi
         # Generate the coverage report.
-        lcov --keep-going --no-external --gcov-tool gcov ${dirs_opts} --capture --output-file lcov.info;
+        lcov ${keep_going_flag} --no-external --gcov-tool gcov ${dirs_opts} --capture --output-file lcov.info
         # The variable $RUNNER_OS should be either "Linux" or "macOS"
         os_lowercase=$(echo $RUNNER_OS | awk '{print tolower($0)}')
         # The prefix will end with "linux" or "macos" depending on the runner OS


### PR DESCRIPTION
The latest version of `lcov` now does more consistency/correctness checking (cf. linux-test-project/lcov#220). We need to instruct it to "keep going" to avoid CI failures.