### PR TITLE
Update the URL for the Codecov PGP public key

### DIFF
--- a/upload-coverage/action.yml
+++ b/upload-coverage/action.yml
@@ -51,8 +51,8 @@ runs:
         export GNUPGHOME="$HOME/gnupg"
         mkdir "$GNUPGHOME"
         chmod 700 "$GNUPGHOME"
-        # Check integrity of the binary uploader (cf. https://docs.codecov.com/docs/codecov-uploader#integrity-checking-the-uploader)
-        curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.kbx --import # One-time step
+        # Check integrity of the binary uploader (cf. https://docs.codecov.com/docs/codecov-uploader#integrity-checking-the-codecov-cli)
+        curl https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.kbx --import # One-time step
         curl -Os "$prefix/codecov.SHA256SUM"
         curl -Os "$prefix/codecov.SHA256SUM.sig"
         gpgv codecov.SHA256SUM.sig codecov.SHA256SUM


### PR DESCRIPTION
Note: Codecov token (which now seems to be required) can be provided through the environment variable `CODECOV_TOKEN`, see https://docs.codecov.com/docs/the-codecov-cli#how-to-upload-to-codecov.