### PR TITLE
Add `num-tasks` input option to the 3 build actions

### DIFF
--- a/build-hypre/action.yml
+++ b/build-hypre/action.yml
@@ -96,7 +96,7 @@ runs:
         cd src;
         ./configure --prefix=${install_prefix} ${hypre_options} CC=mpicc CXX=mpic++ || {
           echo "Hypre configuration failed. Contents of 'config.log':"
-          [[ -e config.log ]] && cat config.log
+          cat config.log
           exit 1
         }
         make -j ${ntasks};

--- a/build-hypre/action.yml
+++ b/build-hypre/action.yml
@@ -10,6 +10,7 @@
 # CONTRIBUTING.md for details.
 
 name: build-hypre
+description: Action to download and build Hypre
 
 inputs:
   url:

--- a/build-hypre/action.yml
+++ b/build-hypre/action.yml
@@ -94,7 +94,11 @@ runs:
         cd ${{ inputs.dir }};
         install_prefix="$(pwd)/install";
         cd src;
-        ./configure --prefix=${install_prefix} ${hypre_options} CC=mpicc CXX=mpic++;
+        ./configure --prefix=${install_prefix} ${hypre_options} CC=mpicc CXX=mpic++ || {
+          echo "Hypre configuration failed. Contents of 'config.log':"
+          [[ -e config.log ]] && cat config.log
+          exit 1
+        }
         make -j ${ntasks};
         make install;
         cd ../..;

--- a/build-hypre/action.yml
+++ b/build-hypre/action.yml
@@ -35,7 +35,7 @@ inputs:
     required: false
     default: fp64
   num-tasks:
-    description: 'number of tasks to use for building: auto, or 1, 2, ...'
+    description: 'Number of tasks to use for building: auto, or 1, 2, ...'
     required: false
     default: 'auto'
 

--- a/build-hypre/action.yml
+++ b/build-hypre/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: 'Precision of the floating point type (fp32,fp64)'
     required: false
     default: fp64
+  num-tasks:
+    description: 'number of tasks to use for building: auto, or 1, 2, ...'
+    required: false
+    default: 'auto'
 
 runs:
   using: "composite"
@@ -80,11 +84,18 @@ runs:
           exit 1;
         fi
         echo "Installing Hypre"
+        ntasks="${{ inputs.num-tasks }}"
+        if [[ "${ntasks}" -ge 1 ]]; then
+          echo "[STATUS] Number of tasks: ${ntasks}"
+        else
+          ntasks=$({ nproc || getconf _NPROCESSORS_ONLN; } 2> /dev/null)
+          echo "[STATUS] Number of tasks: auto: ${ntasks}"
+        fi
         cd ${{ inputs.dir }};
         install_prefix="$(pwd)/install";
         cd src;
         ./configure --prefix=${install_prefix} ${hypre_options} CC=mpicc CXX=mpic++;
-        make -j3;
+        make -j ${ntasks};
         make install;
         cd ../..;
       shell: bash
@@ -114,12 +125,19 @@ runs:
           exit 1;
         fi
         echo "Installing Hypre"
+        ntasks="${{ inputs.num-tasks }}"
+        if [[ "${ntasks}" -ge 1 ]]; then
+          echo "[STATUS] Number of tasks: ${ntasks}"
+        else
+          ntasks=$({ nproc || getconf _NPROCESSORS_ONLN; } 2> /dev/null)
+          echo "[STATUS] Number of tasks: auto: ${ntasks}"
+        fi
         cd ${{ inputs.dir }};
         cmake -Hsrc -Bbuild \
           ${hypre_options} \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=install
-        cmake --build build --config Release --parallel 3
+        cmake --build build --config Release --parallel ${ntasks}
         cmake --install build --config Release
         cd ../..;
       shell: bash

--- a/build-metis/action.yml
+++ b/build-metis/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: 'Metis top directory name'
     required: true
   num-tasks:
-    description: 'number of tasks to use for building: auto, or 1, 2, ...'
+    description: 'Number of tasks to use for building: auto, or 1, 2, ...'
     required: false
     default: 'auto'
 

--- a/build-metis/action.yml
+++ b/build-metis/action.yml
@@ -10,6 +10,7 @@
 # CONTRIBUTING.md for details.
 
 name: build-metis
+description: Action to download and build METIS
 
 inputs:
   url:

--- a/build-metis/action.yml
+++ b/build-metis/action.yml
@@ -22,6 +22,10 @@ inputs:
   dir:
     description: 'Metis top directory name'
     required: true
+  num-tasks:
+    description: 'number of tasks to use for building: auto, or 1, 2, ...'
+    required: false
+    default: 'auto'
 
 runs:
   using: "composite"
@@ -31,5 +35,12 @@ runs:
         wget --no-verbose ${{ inputs.url }}/${{ inputs.archive }};
         rm -rf ${{ inputs.dir }};
         tar -xzf ${{ inputs.archive }};
-        make -j3 -C ${{ inputs.dir }}/Lib CC=mpicc OPTFLAGS="-Wno-error=implicit-function-declaration -O2";
+        ntasks="${{ inputs.num-tasks }}"
+        if [[ "${ntasks}" -ge 1 ]]; then
+          echo "[STATUS] Number of tasks: ${ntasks}"
+        else
+          ntasks=$({ nproc || getconf _NPROCESSORS_ONLN; } 2> /dev/null)
+          echo "[STATUS] Number of tasks: auto: ${ntasks}"
+        fi
+        make -j ${ntasks} -C ${{ inputs.dir }}/Lib CC=mpicc OPTFLAGS="-Wno-error=implicit-function-declaration -O2";
       shell: bash

--- a/build-mfem/action.yml
+++ b/build-mfem/action.yml
@@ -61,7 +61,7 @@ inputs:
     required: false
     default: ''
   num-tasks:
-    description: 'number of tasks to use for building: auto, or 1, 2, ...'
+    description: 'Number of tasks to use for building: auto, or 1, 2, ...'
     required: false
     default: 'auto'
 

--- a/build-mfem/action.yml
+++ b/build-mfem/action.yml
@@ -10,6 +10,7 @@
 # CONTRIBUTING.md for details.
 
 name: build-mfem
+description: Action to build MFEM
 
 inputs:
   os:

--- a/build-mfem/action.yml
+++ b/build-mfem/action.yml
@@ -60,6 +60,10 @@ inputs:
     description: 'extra options to pass to build configuration'
     required: false
     default: ''
+  num-tasks:
+    description: 'number of tasks to use for building: auto, or 1, 2, ...'
+    required: false
+    default: 'auto'
 
 runs:
   using: "composite"
@@ -161,6 +165,13 @@ runs:
       run: |
         echo "------------------"
         echo "--- Build mfem ---"
+        ntasks="${{ inputs.num-tasks }}"
+        if [[ "${ntasks}" -ge 1 ]]; then
+            echo "[STATUS] Number of tasks: ${ntasks}"
+        else
+            ntasks=$({ nproc || getconf _NPROCESSORS_ONLN; } 2> /dev/null)
+            echo "[STATUS] Number of tasks: auto: ${ntasks}"
+        fi
         BUILD_TYPE="Release"
         [[ ${{ inputs.target }} == 'dbg' ]] && BUILD_TYPE="Debug";
         cd ${{ inputs.mfem-dir }}
@@ -168,13 +179,13 @@ runs:
             CMAKE_TARGET="exec"
             [[ ${{ inputs.library-only }} == 'true' ]] && CMAKE_TARGET="mfem";
             cd build
-            cmake --build . --parallel 3 --target ${CMAKE_TARGET} --config "${BUILD_TYPE}"
+            cmake --build . --parallel ${ntasks} --target ${CMAKE_TARGET} --config "${BUILD_TYPE}"
             if [[ ${{ inputs.library-only }} == 'false' ]]; then
-              cmake --build tests/unit --parallel 3 --config "${BUILD_TYPE}"
+              cmake --build tests/unit --parallel ${ntasks} --config "${BUILD_TYPE}"
             fi
         else
             MAKE_TARGET="all"
             [[ ${{ inputs.library-only }} == 'true' ]] && MAKE_TARGET="";
-            make ${MAKE_TARGET} -j3
+            make ${MAKE_TARGET} -j ${ntasks}
         fi
       shell: bash

--- a/upload-coverage/action.yml
+++ b/upload-coverage/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: "Path to the project directory"
     required: true
   directories:
-    descripton: "List of directories to look for coverage info"
+    description: "List of directories to look for coverage info"
     required: false
 
 runs:


### PR DESCRIPTION
Add `num-tasks` input option to the 3 build actions, `build-{mfem,hypre,metis}`, that allows setting the number of tasks to be used for building. The default value, `auto`, will auto-detect the number of available CPU cores.

Also, for debugging purposes, show the log file output when the hypre configuration step fails.
